### PR TITLE
fix: Space filter bug and pulse directory location

### DIFF
--- a/config/datacortex.yaml
+++ b/config/datacortex.yaml
@@ -16,7 +16,7 @@ server:
 
 # Pulse settings
 pulse:
-  directory: pulses
+  directory: .datacore/pulses
   schedule: manual  # daily, weekly, manual
 
 # Graph generation settings
@@ -31,3 +31,24 @@ graph:
 visualization:
   node_size_metric: degree  # degree, centrality
   color_by: type  # type, space, cluster
+
+# AI settings
+ai:
+  # === Embeddings ===
+  # Local embedding model (sentence-transformers)
+  embedding_model: sentence-transformers/all-mpnet-base-v2
+
+  # Content to embed: title + first N chars of content
+  content_length: 500
+
+  # Batch size for embedding computation
+  batch_size: 32
+
+  # === Q&A Synthesis ===
+  # LLM for answering questions (when running standalone, not in Claude Code)
+  # Options: claude-3-haiku-20240307, claude-3-5-sonnet-20241022, claude-sonnet-4-20250514
+  qa_model: claude-3-haiku-20240307
+
+  # API key from env: ANTHROPIC_API_KEY or .datacore/env/anthropic.env
+  # Max tokens for answer generation
+  qa_max_tokens: 1024


### PR DESCRIPTION
## Summary

- Fix space filter checkbox bug (complete rewrite with inclusion-based model)
- Fix pulse directory from relative `pulses` to `.datacore/pulses`
- Add title-based path finding (partial title match instead of full node IDs)
- Add debounce (300ms) to prevent rapid-fire filter requests

## Changes

**`config/datacortex.yaml`**
- Changed `pulse.directory` from `pulses` (relative) to `.datacore/pulses` (keeps all state under `.datacore/`)

**`frontend/js/app.js`**
- Complete rewrite of filter model: inclusion-based (checked = included) instead of exclusion-based
- Added `allSpaces`/`allTypes` Sets to track available options
- Added `findNodeByTitle()` for partial title matching in path finder
- Added debounce utility to prevent rapid-fire API calls

## Test plan

- [ ] Start server: `datacortex serve`
- [ ] Open http://localhost:8765
- [ ] Check/uncheck space filters - verify nodes update correctly
- [ ] Check/uncheck type filters - verify nodes update correctly
- [ ] Use path finder with partial titles (e.g., "fair data" instead of full node ID)
- [ ] Run `datacortex pulse generate` - verify saves to `.datacore/pulses/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)